### PR TITLE
Diamant full rules and GUI

### DIFF
--- a/src/main/java/games/GameType.java
+++ b/src/main/java/games/GameType.java
@@ -47,6 +47,7 @@ import games.diamant.*;
 import games.diamant.DiamantForwardModel;
 import games.diamant.DiamantGameState;
 import games.diamant.DiamantParameters;
+import games.diamant.gui.DiamantGUIManager;
 import games.dominion.*;
 import games.dominion.gui.DominionGUIManager;
 import games.dotsboxes.DBForwardModel;
@@ -218,7 +219,7 @@ public enum GameType {
     Diamant(2, 6,
             Arrays.asList(Adventure, Bluffing, Exploration),
             Arrays.asList(MoveThroughDeck, PushYourLuck, SimultaneousActionSelection),
-            DiamantGameState.class, DiamantForwardModel.class, DiamantParameters.class, null),
+            DiamantGameState.class, DiamantForwardModel.class, DiamantParameters.class, DiamantGUIManager.class),
     Dominion(2, 4,
             Arrays.asList(Cards, Strategy),
             Collections.singletonList(DeckManagement),

--- a/src/main/java/games/diamant/DiamantFeatures.java
+++ b/src/main/java/games/diamant/DiamantFeatures.java
@@ -3,7 +3,11 @@ package games.diamant;
 import core.AbstractGameState;
 import core.interfaces.IStateFeatureJSON;
 import core.interfaces.IStateFeatureVector;
+import games.diamant.cards.DiamantCard;
 import org.json.simple.JSONObject;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class DiamantFeatures implements IStateFeatureVector, IStateFeatureJSON {
 
@@ -11,15 +15,16 @@ public class DiamantFeatures implements IStateFeatureVector, IStateFeatureJSON {
     public String getObservationJson(AbstractGameState gameState, int playerId) {
         DiamantGameState gs = (DiamantGameState) gameState;
         final JSONObject json = new JSONObject();
+        Map< DiamantCard.HazardType, Long> hazardsOnPath = gs.getHazardsOnPath();
         json.put("cave", gs.nCave);
         json.put("playersInCave", gs.playerInCave.size());
         json.put("pathNoGems", gs.gemsOnPath);
         json.put("chestNoGems", gs.getTreasureChests().get(playerId).getValue());
-        json.put("hazardScorpionsOnPath", gs.nHazardExplosionsOnPath);
-        json.put("hazardSnakesOnPath", gs.nHazardSnakesOnPath);
-        json.put("hazardRockfallsOnPath", gs.nHazardRockfallsOnPath);
-        json.put("hazardPoisonOnPath", gs.nHazardPoisonGasOnPath);
-        json.put("hazardExplosionsOnPath", gs.nHazardExplosionsOnPath);
+        json.put("hazardScorpionsOnPath", hazardsOnPath.get(DiamantCard.HazardType.Scorpions));
+        json.put("hazardSnakesOnPath", hazardsOnPath.get(DiamantCard.HazardType.Snakes));
+        json.put("hazardPoisonGasOnPath", hazardsOnPath.get(DiamantCard.HazardType.PoisonGas));
+        json.put("hazardExplosionsOnPath", hazardsOnPath.get(DiamantCard.HazardType.Explosions));
+        json.put("hazardRockfallsOnPath", hazardsOnPath.get(DiamantCard.HazardType.Rockfalls));
         return json.toJSONString();
     }
 
@@ -36,15 +41,14 @@ public class DiamantFeatures implements IStateFeatureVector, IStateFeatureJSON {
         retVal[1] = gs.path.getComponents().get(gs.path.getSize()-1).getValue(); // nGemsOnPath;
         retVal[2] = gs.playerInCave.size();
         retVal[3] = gs.nCave;
-        retVal[4] = gs.nHazardExplosionsOnPath;
-        retVal[5] = gs.nHazardPoisonGasOnPath;
-        retVal[6] = gs.nHazardRockfallsOnPath;
-        retVal[7] = gs.nHazardScorpionsOnPath;
-        retVal[8] = gs.nHazardSnakesOnPath;
+        Map< DiamantCard.HazardType, Long> hazardsOnPath = gs.getHazardsOnPath();
+        retVal[4] = hazardsOnPath.get(DiamantCard.HazardType.Explosions) != null ? hazardsOnPath.get(DiamantCard.HazardType.Explosions) : 0;
+        retVal[5] = hazardsOnPath.get(DiamantCard.HazardType.PoisonGas) != null ? hazardsOnPath.get(DiamantCard.HazardType.PoisonGas) : 0;
+        retVal[6] = hazardsOnPath.get(DiamantCard.HazardType.Rockfalls) != null ? hazardsOnPath.get(DiamantCard.HazardType.Rockfalls) : 0;
+        retVal[7] = hazardsOnPath.get(DiamantCard.HazardType.Scorpions) != null ? hazardsOnPath.get(DiamantCard.HazardType.Scorpions) : 0;
+        retVal[8] = hazardsOnPath.get(DiamantCard.HazardType.Snakes) != null ? hazardsOnPath.get(DiamantCard.HazardType.Snakes) : 0;
         return retVal;
     }
-
-
 
     public int getObservationSpace() {
         return names().length;

--- a/src/main/java/games/diamant/DiamantFeatures.java
+++ b/src/main/java/games/diamant/DiamantFeatures.java
@@ -3,6 +3,7 @@ package games.diamant;
 import core.AbstractGameState;
 import core.interfaces.IStateFeatureJSON;
 import core.interfaces.IStateFeatureVector;
+import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
 public class DiamantFeatures implements IStateFeatureVector, IStateFeatureJSON {
@@ -13,12 +14,12 @@ public class DiamantFeatures implements IStateFeatureVector, IStateFeatureJSON {
         final JSONObject json = new JSONObject();
         json.put("cave", gs.nCave);
         json.put("playersInCave", gs.playerInCave.size());
-        json.put("pathNoGems", gs.nGemsOnPath);
+        json.put("pathNoGems", gs.gemsOnPath);
         json.put("chestNoGems", gs.getTreasureChests().get(playerId).getValue());
         json.put("hazardScorpionsOnPath", gs.nHazardExplosionsOnPath);
         json.put("hazardSnakesOnPath", gs.nHazardSnakesOnPath);
         json.put("hazardRockfallsOnPath", gs.nHazardRockfallsOnPath);
-        json.put("hazardPoisonOnPath", gs.nHazardPoissonGasOnPath);
+        json.put("hazardPoisonOnPath", gs.nHazardPoisonGasOnPath);
         json.put("hazardExplosionsOnPath", gs.nHazardExplosionsOnPath);
         return json.toJSONString();
     }
@@ -37,26 +38,12 @@ public class DiamantFeatures implements IStateFeatureVector, IStateFeatureJSON {
         retVal[2] = gs.playerInCave.size();
         retVal[3] = gs.nCave;
         retVal[4] = gs.nHazardExplosionsOnPath;
-        retVal[5] = gs.nHazardPoissonGasOnPath;
+        retVal[5] = gs.nHazardPoisonGasOnPath;
         retVal[6] = gs.nHazardRockfallsOnPath;
         retVal[7] = gs.nHazardScorpionsOnPath;
         retVal[8] = gs.nHazardSnakesOnPath;
         return retVal;
     }
-
-//    public double[] normFeatureVector() {
-//        double[] retVal = new double[getObservationSpace()];
-//        retVal[0] = getTreasureChests().get(getCurrentPlayer()).getValue() / 100d;
-//        retVal[1] = path.getComponents().get(path.getSize()-1).getNumberOfGems() / 17d;
-//        retVal[2] = playerInCave.size() / (double) getNPlayers();
-//        retVal[3] = nCave / 5d;
-//        retVal[4] = nHazardExplosionsOnPath / 3d;
-//        retVal[5] = nHazardPoissonGasOnPath/ 3d;
-//        retVal[6] = nHazardRockfallsOnPath /3d;
-//        retVal[7] = nHazardScorpionsOnPath /3d;
-//        retVal[8] = nHazardSnakesOnPath/ 3d;
-//        return retVal;
-//    }
 
 
 

--- a/src/main/java/games/diamant/DiamantFeatures.java
+++ b/src/main/java/games/diamant/DiamantFeatures.java
@@ -3,7 +3,6 @@ package games.diamant;
 import core.AbstractGameState;
 import core.interfaces.IStateFeatureJSON;
 import core.interfaces.IStateFeatureVector;
-import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
 public class DiamantFeatures implements IStateFeatureVector, IStateFeatureJSON {
@@ -34,7 +33,7 @@ public class DiamantFeatures implements IStateFeatureVector, IStateFeatureJSON {
         DiamantGameState gs = (DiamantGameState) gameState;
         double[] retVal = new double[getObservationSpace()];
         retVal[0] = gs.getTreasureChests().get(playerId).getValue();
-        retVal[1] = gs.path.getComponents().get(gs.path.getSize()-1).getNumberOfGems(); // nGemsOnPath;
+        retVal[1] = gs.path.getComponents().get(gs.path.getSize()-1).getValue(); // nGemsOnPath;
         retVal[2] = gs.playerInCave.size();
         retVal[3] = gs.nCave;
         retVal[4] = gs.nHazardExplosionsOnPath;

--- a/src/main/java/games/diamant/DiamantForwardModel.java
+++ b/src/main/java/games/diamant/DiamantForwardModel.java
@@ -160,6 +160,8 @@ public class DiamantForwardModel extends StandardForwardModel implements ITreeAc
     private void prepareNewCave(DiamantGameState dgs) {
         DiamantParameters dp = (DiamantParameters) dgs.getGameParameters();
 
+        endRound(dgs);
+
         dgs.nCave++;
 
         // No more caves ?

--- a/src/main/java/games/diamant/DiamantGameState.java
+++ b/src/main/java/games/diamant/DiamantGameState.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 
 public class DiamantGameState extends AbstractGameState implements IPrintable {
@@ -25,6 +26,13 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
     List<Counter> treasureChests;
     List<Counter> hands;
     List<Boolean> playerInCave;
+
+    public List<Integer> getPlayersInCave() {
+        return IntStream.range(0, getNPlayers())
+                .filter(i -> playerInCave.get(i))
+                .boxed()
+                .collect(Collectors.toList());
+    }
 
     // helper data class to store interesting information
     static class PlayerTurnRecord {

--- a/src/main/java/games/diamant/DiamantGameState.java
+++ b/src/main/java/games/diamant/DiamantGameState.java
@@ -22,6 +22,7 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
     Deck<DiamantCard>          mainDeck;
     Deck<DiamantCard>          discardDeck;
     Deck<DiamantCard>          path;
+    Deck<DiamantCard>          relicDeck;
 
     List<Counter> treasureChests;
     List<Counter> hands;
@@ -84,6 +85,7 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
             add(mainDeck);
             add(discardDeck);
             add(path);
+            if (relicDeck != null) add(relicDeck);
             addAll(treasureChests);
             addAll(hands);
             add(actionsPlayed);
@@ -98,6 +100,7 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
         dgs.mainDeck    = mainDeck.copy();
         dgs.discardDeck = discardDeck.copy();
         dgs.path        = path.copy();
+        if (relicDeck != null) dgs.relicDeck = relicDeck.copy();
         dgs.actionsPlayed  = (ActionsPlayed) actionsPlayed.copy();
 
         dgs.gemsOnPath = new ArrayList<>(gemsOnPath);
@@ -302,6 +305,7 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
     public List<Counter>     getTreasureChests() { return treasureChests; }
     public Deck<DiamantCard> getPath()           { return path;           }
     public ActionsPlayed     getActionsPlayed()  { return actionsPlayed;  }
+    public Deck<DiamantCard> getRelicDeck()      { return relicDeck;      }
     public void setActionPlayed(int player, AbstractAction action) {
         actionsPlayed.put(player, action);
     }

--- a/src/main/java/games/diamant/DiamantParameters.java
+++ b/src/main/java/games/diamant/DiamantParameters.java
@@ -8,15 +8,18 @@ import games.GameType;
 import java.util.Arrays;
 
 public class DiamantParameters extends TunableParameters {
-    public int nCaves              = 5;
+    public int nCaves = 5;
     public int nHazardCardsPerType = 3;
-    public int nHazardsToDead      = 2;
-    public int[] treasures         = new int[]{1, 2, 3, 4, 5, 7, 9, 10, 11, 12, 13, 14, 15, 16, 17};
+    public int nHazardsToDead = 2;
+    public int[] treasures = new int[]{1, 2, 3, 4, 5, 7, 9, 10, 11, 12, 13, 14, 15, 16, 17};
+    public boolean relicVariant = false;
+    public int[] relics = new int[]{5, 7, 8, 10, 12};
 
     public DiamantParameters() {
-        addTunableParameter("nCaves", 5, Arrays.asList(3,5,7,10));
-        addTunableParameter("nHazardCardsPerType", 3, Arrays.asList(1,3,4,7,10));
-        addTunableParameter("nHazardsToDead", 2, Arrays.asList(1,2,3,4,5));
+        addTunableParameter("nCaves", 5, Arrays.asList(3, 5, 7, 10));
+        addTunableParameter("nHazardCardsPerType", 3, Arrays.asList(1, 3, 4, 7, 10));
+        addTunableParameter("nHazardsToDead", 2, Arrays.asList(1, 2, 3, 4, 5));
+        addTunableParameter("relicVariant", false, Arrays.asList(true, false));
         _reset();
     }
 
@@ -25,30 +28,26 @@ public class DiamantParameters extends TunableParameters {
         nCaves = (int) getParameterValue("nCaves");
         nHazardCardsPerType = (int) getParameterValue("nHazardCardsPerType");
         nHazardsToDead = (int) getParameterValue("nHazardsToDead");
+        relicVariant = (boolean) getParameterValue("relicVariant");
     }
 
     @Override
     protected AbstractParameters _copy() {
         DiamantParameters copy = new DiamantParameters();
-        copy.nCaves              = nCaves;
-        copy.nHazardCardsPerType = nHazardCardsPerType;
-        copy.nHazardsToDead      = nHazardsToDead;
-        copy.treasures           = new int[treasures.length];
+        // tunable parameters are copied automatically by super class
+        copy.treasures = new int[treasures.length];
+        copy.relics = new int[relics.length];
         System.arraycopy(treasures, 0, copy.treasures, 0, treasures.length);
+        System.arraycopy(relics, 0, copy.relics, 0, relics.length);
         return copy;
     }
 
     @Override
     protected boolean _equals(Object o) {
-        if (this == o)                         return true;
-        if (!(o instanceof DiamantParameters)) return false;
-        if (!super.equals(o))                  return false;
-
-        DiamantParameters that = (DiamantParameters) o;
-        return nCaves              == that.nCaves              &&
-               nHazardCardsPerType == that.nHazardCardsPerType &&
-               nHazardsToDead      == that.nHazardsToDead      &&
-               Arrays.equals(treasures, that.treasures);
+        if (o instanceof DiamantParameters that) {
+            return Arrays.equals(treasures, that.treasures) && Arrays.equals(relics, that.relics);
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/games/diamant/DiamantParameters.java
+++ b/src/main/java/games/diamant/DiamantParameters.java
@@ -19,7 +19,7 @@ public class DiamantParameters extends TunableParameters {
         addTunableParameter("nCaves", 5, Arrays.asList(3, 5, 7, 10));
         addTunableParameter("nHazardCardsPerType", 3, Arrays.asList(1, 3, 4, 7, 10));
         addTunableParameter("nHazardsToDead", 2, Arrays.asList(1, 2, 3, 4, 5));
-        addTunableParameter("relicVariant", false, Arrays.asList(true, false));
+        addTunableParameter("relicVariant", true, Arrays.asList(true, false));
         _reset();
     }
 

--- a/src/main/java/games/diamant/DiamantSimpleFeatures.java
+++ b/src/main/java/games/diamant/DiamantSimpleFeatures.java
@@ -2,6 +2,7 @@ package games.diamant;
 
 import core.AbstractGameState;
 import evaluation.features.TunableStateFeatures;
+import games.diamant.cards.DiamantCard;
 import players.heuristics.LeaderHeuristic;
 
 public class DiamantSimpleFeatures extends TunableStateFeatures {
@@ -24,13 +25,9 @@ public class DiamantSimpleFeatures extends TunableStateFeatures {
         retVal[3] = gs.nCave;
 
         // hazards on path - we only care about if we have seen a type or not
-        int hazards = 0;
-        hazards += gs.nHazardExplosionsOnPath;
-        hazards += gs.nHazardPoisonGasOnPath;
-        hazards += gs.nHazardRockfallsOnPath;
-        hazards += gs.nHazardScorpionsOnPath;
-        hazards += gs.nHazardSnakesOnPath;
-        retVal[4] = hazards;
+        retVal[4] = gs.getPath().stream().
+                filter(c -> c.getCardType() == DiamantCard.DiamantCardType.Hazard)
+                .count();
 
         // player's ordinal position
         retVal[5] = gs.getOrdinalPosition(playerId);

--- a/src/main/java/games/diamant/DiamantSimpleFeatures.java
+++ b/src/main/java/games/diamant/DiamantSimpleFeatures.java
@@ -19,7 +19,7 @@ public class DiamantSimpleFeatures extends TunableStateFeatures {
 
         double[] retVal = new double[allNames.length];
         retVal[0] = gs.getTreasureChests().get(playerId).getValue();
-        retVal[1] = gs.path.getComponents().get(gs.path.getSize()-1).getNumberOfGems(); // nGemsOnPath;
+        retVal[1] = gs.path.getComponents().get(gs.path.getSize()-1).getValue(); // nGemsOnPath;
         retVal[2] = gs.playerInCave.size();
         retVal[3] = gs.nCave;
 

--- a/src/main/java/games/diamant/DiamantSimpleFeatures.java
+++ b/src/main/java/games/diamant/DiamantSimpleFeatures.java
@@ -26,7 +26,7 @@ public class DiamantSimpleFeatures extends TunableStateFeatures {
         // hazards on path - we only care about if we have seen a type or not
         int hazards = 0;
         hazards += gs.nHazardExplosionsOnPath;
-        hazards += gs.nHazardPoissonGasOnPath;
+        hazards += gs.nHazardPoisonGasOnPath;
         hazards += gs.nHazardRockfallsOnPath;
         hazards += gs.nHazardScorpionsOnPath;
         hazards += gs.nHazardSnakesOnPath;

--- a/src/main/java/games/diamant/cards/DiamantCard.java
+++ b/src/main/java/games/diamant/cards/DiamantCard.java
@@ -13,7 +13,7 @@ public class DiamantCard extends Card {
     public enum HazardType {
         Scorpions,
         Snakes,
-        PoissonGas,
+        PoisonGas,
         Explosions,
         Rockfalls,
         None

--- a/src/main/java/games/diamant/cards/DiamantCard.java
+++ b/src/main/java/games/diamant/cards/DiamantCard.java
@@ -44,10 +44,11 @@ public class DiamantCard extends Card {
 
     @Override
     public String toString() {
-        String str = "";
-        if      (cardType == DiamantCardType.Treasure) str = "DiamantCard { Treasure : " + value + "}";
-        else if (cardType == DiamantCardType.Hazard)   str = "DiamantCard { Hazard : " + hazardType.toString() + "}";
-        return str;
+        return switch(cardType) {
+            case Treasure -> "Treasure " + value;
+            case Hazard -> hazardType.toString();
+            case Relic -> "Relic " + value;
+        };
     }
 
     @Override

--- a/src/main/java/games/diamant/cards/DiamantCard.java
+++ b/src/main/java/games/diamant/cards/DiamantCard.java
@@ -7,7 +7,8 @@ public class DiamantCard extends Card {
 
     public enum DiamantCardType {
         Treasure,
-        Hazard
+        Hazard,
+        Relic
     }
 
     public enum HazardType {
@@ -21,30 +22,30 @@ public class DiamantCard extends Card {
 
     private final DiamantCardType cardType;
     private final HazardType      hazardType;
-    private final int             NumberOfGems;
+    private final int value;
 
     public DiamantCard(DiamantCardType cardType, HazardType hazardType, int NumberOfGems) {
         super(cardType.toString());
         this.cardType     = cardType;
         this.hazardType   = hazardType;
-        this.NumberOfGems = NumberOfGems;
+        this.value = NumberOfGems;
     }
 
     public DiamantCard(DiamantCardType cardType, HazardType hazardType, int NumberOfGems, int ID) {
         super(cardType.toString(), ID);
         this.cardType     = cardType;
         this.hazardType   = hazardType;
-        this.NumberOfGems = NumberOfGems;
+        this.value = NumberOfGems;
     }
 
     public DiamantCardType getCardType()     { return cardType;     }
     public HazardType      getHazardType()   { return hazardType;   }
-    public int             getNumberOfGems() { return NumberOfGems; }
+    public int getValue() { return value; }
 
     @Override
     public String toString() {
         String str = "";
-        if      (cardType == DiamantCardType.Treasure) str = "DiamantCard { Treasure : " + NumberOfGems + "}";
+        if      (cardType == DiamantCardType.Treasure) str = "DiamantCard { Treasure : " + value + "}";
         else if (cardType == DiamantCardType.Hazard)   str = "DiamantCard { Hazard : " + hazardType.toString() + "}";
         return str;
     }

--- a/src/main/java/games/diamant/gui/DiamantBoardView.java
+++ b/src/main/java/games/diamant/gui/DiamantBoardView.java
@@ -1,0 +1,163 @@
+package games.diamant.gui;
+
+import games.diamant.DiamantGameState;
+import games.diamant.cards.DiamantCard;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class DiamantBoardView extends JComponent {
+
+    static final int CARD_WIDTH = 70;
+    static final int CARD_HEIGHT = 100;
+    static final int CARD_SPACING = 20;
+    static final int PLAYER_CIRCLE_DIAM = 18;
+    static final int CAMPSITE_X = 40;
+    static final int CAMPSITE_Y = 220;
+    static final int CAMPSITE_WIDTH = 120;
+    static final int CAMPSITE_HEIGHT = 80;
+    static final Color[] PLAYER_COLOURS = new Color[]{Color.GREEN, Color.RED, Color.BLUE, Color.YELLOW, Color.MAGENTA, Color.ORANGE, Color.CYAN, Color.PINK};
+
+    List<DiamantCard> path;
+    List<Integer> gemsOnPath;
+    List<Integer> playersInCave;
+    int nCavesLeft;
+    Map<DiamantCard.HazardType, Integer> discardedHazards;
+    int nPlayers;
+
+    public DiamantBoardView(DiamantGameState state) {
+        setPreferredSize(new Dimension(800, 400));
+        update(state);
+    }
+
+    public synchronized void update(DiamantGameState state) {
+        path = state.getPath().getComponents();
+        gemsOnPath = state.getGemsOnPathList();
+        playersInCave = new ArrayList<>(state.getPlayersInCave());
+        nPlayers = state.getNPlayers();
+        int totalCaves = ((games.diamant.DiamantParameters) state.getGameParameters()).nCaves;
+        nCavesLeft = totalCaves - state.getRoundCounter();
+
+        // Count discarded hazards by type
+        discardedHazards = new EnumMap<>(DiamantCard.HazardType.class);
+        for (DiamantCard.HazardType ht : DiamantCard.HazardType.values()) {
+            if (ht != DiamantCard.HazardType.None) {
+                discardedHazards.put(ht, 0);
+            }
+        }
+        for (int i = 0; i < state.getDiscardDeck().getSize(); i++) {
+            DiamantCard c = state.getDiscardDeck().get(i);
+            if (c.getCardType() == DiamantCard.DiamantCardType.Hazard) {
+                DiamantCard.HazardType ht = c.getHazardType();
+                discardedHazards.put(ht, discardedHazards.get(ht) + 1);
+            }
+        }
+        repaint();
+    }
+
+    @Override
+    public synchronized void paintComponent(Graphics graphics) {
+        Graphics2D g = (Graphics2D) graphics;
+        g.setFont(new Font("Arial", Font.BOLD, 16));
+
+        // Calculate how many cards fit per row
+        int availableWidth = getWidth() - 220; // leave space for campsite and margin
+        int cardsPerRow = Math.max(1, availableWidth / (CARD_WIDTH + CARD_SPACING));
+        int startX = 200;
+        int startY = 60;
+        int rowSpacing = 30;
+
+        int pathSize = path.size();
+        for (int i = 0; i < pathSize; i++) {
+            // The oldest card (last in main deck, index 0 in path) is at the top left, newest at the end
+            int cardIdx = pathSize - 1 - i;
+            int row = i / cardsPerRow;
+            int col = i % cardsPerRow;
+            int cardX = startX + col * (CARD_WIDTH + CARD_SPACING);
+            int cardY = startY + row * (CARD_HEIGHT + rowSpacing);
+
+            // Correct mapping: gemsOnPath is reversed relative to path
+            int gemsIdx = gemsOnPath.size() - 1 - cardIdx;
+            int gems = (gemsIdx >= 0 && gemsIdx < gemsOnPath.size()) ? gemsOnPath.get(gemsIdx) : 0;
+
+            drawCard(g, path.get(cardIdx), cardX, cardY, gems);
+
+            // Draw player circles on the most recent card (rightmost, last card drawn, i==pathSize-1)
+            if (i == pathSize - 1 && pathSize > 0) {
+                int circleY = cardY + CARD_HEIGHT + 10;
+                int circleX = cardX + 5;
+                int offset = 0;
+                for (int p = 0; p < nPlayers; p++) {
+                    if (playersInCave.contains(p)) {
+                        g.setColor(PLAYER_COLOURS[p % PLAYER_COLOURS.length]);
+                        g.fillOval(circleX + offset, circleY, PLAYER_CIRCLE_DIAM, PLAYER_CIRCLE_DIAM);
+                        g.setColor(Color.BLACK);
+                        g.drawOval(circleX + offset, circleY, PLAYER_CIRCLE_DIAM, PLAYER_CIRCLE_DIAM);
+                        offset += PLAYER_CIRCLE_DIAM + 4;
+                    }
+                }
+            }
+        }
+        // Draw campsite area
+        g.setColor(new Color(230, 230, 200));
+        g.fillRect(CAMPSITE_X, CAMPSITE_Y, CAMPSITE_WIDTH, CAMPSITE_HEIGHT);
+        g.setColor(Color.BLACK);
+        g.drawRect(CAMPSITE_X, CAMPSITE_Y, CAMPSITE_WIDTH, CAMPSITE_HEIGHT);
+        g.drawString("Campsite", CAMPSITE_X + 20, CAMPSITE_Y + 20);
+        // Draw player circles in campsite for those not in cave
+        int campCircleX = CAMPSITE_X + 10;
+        int campCircleY = CAMPSITE_Y + 35;
+        int campOffset = 0;
+        for (int p = 0; p < nPlayers; p++) {
+            if (!playersInCave.contains(p)) {
+                g.setColor(PLAYER_COLOURS[p % PLAYER_COLOURS.length]);
+                g.fillOval(campCircleX + campOffset, campCircleY, PLAYER_CIRCLE_DIAM, PLAYER_CIRCLE_DIAM);
+                g.setColor(Color.BLACK);
+                g.drawOval(campCircleX + campOffset, campCircleY, PLAYER_CIRCLE_DIAM, PLAYER_CIRCLE_DIAM);
+                campOffset += PLAYER_CIRCLE_DIAM + 4;
+            }
+        }
+        // Draw caves left
+        g.setColor(Color.BLACK);
+        g.drawString("Caves left: " + nCavesLeft, 30, 40);
+
+        // Draw discarded hazards
+        g.drawString("Discarded Hazards:", 30, 340);
+        int hazardY = 360;
+        int hazardX = 30;
+        for (DiamantCard.HazardType ht : DiamantCard.HazardType.values()) {
+            if (ht == DiamantCard.HazardType.None) continue;
+            g.drawString(ht.name() + ": " + discardedHazards.get(ht), hazardX, hazardY);
+            hazardY += 20;
+        }
+    }
+
+    private void drawCard(Graphics2D g, DiamantCard card, int x, int y, int gemsOnCard) {
+        // Card background
+        g.setColor(Color.WHITE);
+        g.fillRoundRect(x, y, CARD_WIDTH, CARD_HEIGHT, 12, 12);
+        g.setColor(Color.BLACK);
+        g.drawRoundRect(x, y, CARD_WIDTH, CARD_HEIGHT, 12, 12);
+
+        // Card type
+        String label;
+        if (card.getCardType() == DiamantCard.DiamantCardType.Treasure) {
+            label = "Treasure";
+            g.setColor(new Color(220, 180, 60));
+            g.fillOval(x + 10, y + 10, 20, 20);
+            g.setColor(Color.BLACK);
+            g.drawString("" + card.getNumberOfGems(), x + 14, y + 25);
+        } else {
+            label = card.getHazardType().name();
+            g.setColor(Color.RED.darker());
+            g.drawString("Hazard", x + 10, y + 25);
+            g.drawString(label, x + 10, y + 45);
+        }
+        // Gems on path (not card value, but gems left on this card)
+        g.setColor(Color.BLUE);
+        g.drawString("Gems: " + gemsOnCard, x + 10, y + CARD_HEIGHT - 15);
+    }
+}

--- a/src/main/java/games/diamant/gui/DiamantBoardView.java
+++ b/src/main/java/games/diamant/gui/DiamantBoardView.java
@@ -136,21 +136,36 @@ public class DiamantBoardView extends JComponent {
 
     private void drawCard(Graphics2D g, DiamantCard card, int x, int y, int gemsOnCard) {
         // Card background
-        g.setColor(Color.WHITE);
+        if (card.getCardType() == DiamantCard.DiamantCardType.Relic) {
+            g.setColor(new Color(255, 215, 0)); // gold
+        } else if (card.getCardType() == DiamantCard.DiamantCardType.Hazard) {
+            g.setColor(new Color(255, 180, 180)); // light red for hazards
+        } else {
+            g.setColor(Color.WHITE);
+        }
         g.fillRoundRect(x, y, CARD_WIDTH, CARD_HEIGHT, 12, 12);
         g.setColor(Color.BLACK);
         g.drawRoundRect(x, y, CARD_WIDTH, CARD_HEIGHT, 12, 12);
 
-        // Card type
-        String label;
+        // Card type and value
         if (card.getCardType() == DiamantCard.DiamantCardType.Treasure) {
-            label = "Treasure";
             g.setColor(new Color(220, 180, 60));
             g.fillOval(x + 10, y + 10, 20, 20);
             g.setColor(Color.BLACK);
             g.drawString("" + card.getValue(), x + 14, y + 25);
-        } else {
-            label = card.getHazardType().name();
+        } else if (card.getCardType() == DiamantCard.DiamantCardType.Relic) {
+            String label = "Relic";
+            g.setColor(Color.BLACK);
+            // Draw "Relic" label at the top, centered
+            FontMetrics fm = g.getFontMetrics();
+            int labelWidth = fm.stringWidth(label);
+            g.drawString(label, x + (CARD_WIDTH - labelWidth) / 2, y + 30);
+            // Draw value centered in the card
+            String valueStr = String.valueOf(card.getValue());
+            int valueWidth = fm.stringWidth(valueStr);
+            g.drawString(valueStr, x + (CARD_WIDTH - valueWidth) / 2, y + CARD_HEIGHT / 2 + fm.getAscent() / 2);
+        } else if (card.getCardType() == DiamantCard.DiamantCardType.Hazard) {
+            String label = card.getHazardType().name();
             g.setColor(Color.RED.darker());
             g.drawString(label, x + 10, y + 25);
         }

--- a/src/main/java/games/diamant/gui/DiamantBoardView.java
+++ b/src/main/java/games/diamant/gui/DiamantBoardView.java
@@ -7,7 +7,6 @@ import javax.swing.*;
 import java.awt.*;
 import java.util.List;
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class DiamantBoardView extends JComponent {
 
@@ -149,7 +148,7 @@ public class DiamantBoardView extends JComponent {
             g.setColor(new Color(220, 180, 60));
             g.fillOval(x + 10, y + 10, 20, 20);
             g.setColor(Color.BLACK);
-            g.drawString("" + card.getNumberOfGems(), x + 14, y + 25);
+            g.drawString("" + card.getValue(), x + 14, y + 25);
         } else {
             label = card.getHazardType().name();
             g.setColor(Color.RED.darker());

--- a/src/main/java/games/diamant/gui/DiamantBoardView.java
+++ b/src/main/java/games/diamant/gui/DiamantBoardView.java
@@ -153,8 +153,7 @@ public class DiamantBoardView extends JComponent {
         } else {
             label = card.getHazardType().name();
             g.setColor(Color.RED.darker());
-            g.drawString("Hazard", x + 10, y + 25);
-            g.drawString(label, x + 10, y + 45);
+            g.drawString(label, x + 10, y + 25);
         }
         // Gems on path (not card value, but gems left on this card)
         g.setColor(Color.BLUE);

--- a/src/main/java/games/diamant/gui/DiamantGUIManager.java
+++ b/src/main/java/games/diamant/gui/DiamantGUIManager.java
@@ -1,0 +1,58 @@
+package games.diamant.gui;
+
+import core.*;
+import games.diamant.DiamantGameState;
+import gui.*;
+import players.human.ActionController;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.Set;
+
+public class DiamantGUIManager extends AbstractGUIManager {
+
+    DiamantBoardView view;
+    static int diamantWidth = 800;
+    static int diamantHeight = 400;
+
+    public DiamantGUIManager(GamePanel parent, Game game, ActionController ac, Set<Integer> humanId) {
+        super(parent, game, ac, humanId);
+        DiamantGameState state = (DiamantGameState) game.getGameState();
+        view = new DiamantBoardView(state);
+
+        width = diamantWidth;
+        height = diamantHeight;
+
+        JPanel infoPanel = createGameStateInfoPanel("Diamant", state, width, defaultInfoPanelHeight);
+        JComponent actionPanel = createActionPanel(new IScreenHighlight[0], width, defaultActionPanelHeight);
+
+        parent.setLayout(new BorderLayout());
+        parent.add(view, BorderLayout.CENTER);
+        parent.add(infoPanel, BorderLayout.NORTH);
+        parent.add(actionPanel, BorderLayout.SOUTH);
+        parent.setPreferredSize(new Dimension(width, height + defaultActionPanelHeight + defaultInfoPanelHeight + 20));
+    }
+
+    /**
+     * Override to remove the history panel from the info panel.
+     */
+    @Override
+    protected JPanel createGameStateInfoPanel(String gameTitle, AbstractGameState gameState, int width, int height) {
+        JPanel retValue = super.createGameStateInfoPanel(gameTitle, gameState, width, height);
+        // Remove the history panel
+        retValue.remove(historyContainer);
+        return retValue;
+    }
+
+    @Override
+    public int getMaxActionSpace() {
+        return 3;
+    }
+
+    @Override
+    protected void _update(AbstractPlayer player, AbstractGameState gameState) {
+        if (gameState != null) {
+            view.update((DiamantGameState) gameState);
+        }
+    }
+}

--- a/src/test/java/games/diamant/DiamantExitTest.java
+++ b/src/test/java/games/diamant/DiamantExitTest.java
@@ -108,10 +108,11 @@ public class DiamantExitTest {
         DiamantGameState state = (DiamantGameState) game.getGameState();
 
         Map<HazardType, Long> initialHazardCounts = state.getNHazardCardsInMainDeck();
-        DiamantCard cardOnPath = state.getPath().peek();
-        if (cardOnPath.getCardType() == Hazard) {
-            initialHazardCounts.merge(cardOnPath.getHazardType(), 1L, Long::sum);
-        }
+        Map<HazardType, Long> onPath = state.getHazardsOnPath();
+        // combine these two maps
+        initialHazardCounts = initialHazardCounts.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue() + onPath.getOrDefault(e.getKey(), 0L)));
+
         int currentCave = state.nCave;
 
         while (state.isNotTerminal()) {
@@ -129,9 +130,10 @@ public class DiamantExitTest {
                 System.out.println(currentCave + " : " + lastCard.getHazardType());
                 assertEquals(Hazard, lastCard.getCardType());
                 Map<HazardType, Long> hazardCounts = state.getNHazardCardsInMainDeck();
-                if (cardOnPath.getCardType() == Hazard) {
-                    hazardCounts.merge(cardOnPath.getHazardType(), 1L, Long::sum);
-                }
+                Map<HazardType, Long> onPath2 = state.getHazardsOnPath();
+                // combine these two maps
+                hazardCounts = hazardCounts.entrySet().stream()
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue() + onPath2.getOrDefault(e.getKey(), 0L)));
                 for (HazardType hazardType : HazardType.values()) {
                     if (hazardType == lastCard.getHazardType()) {
                         assertEquals(1, initialHazardCounts.get(lastCard.getHazardType()) - hazardCounts.get(lastCard.getHazardType()));                    }

--- a/src/test/java/games/diamant/DiamantExitTest.java
+++ b/src/test/java/games/diamant/DiamantExitTest.java
@@ -9,7 +9,6 @@ import games.diamant.cards.DiamantCard;
 import games.diamant.cards.DiamantCard.HazardType;
 import org.junit.Test;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -53,7 +52,7 @@ public class DiamantExitTest {
                 fm.next(state, actions[i]);
             }
             assertEquals(0, state.getCurrentPlayer());
-            assertEquals(5, state.getPath().get(0).getNumberOfGems());
+            assertEquals(5, state.getPath().get(0).getValue());
 
             // After the move, 2 players should have left the cave, 2 remain
             assertEquals(2, state.playerInCave.stream().filter(b -> b).count());
@@ -85,7 +84,7 @@ public class DiamantExitTest {
             System.out.println(state.getPath().get(0));
 
             DiamantCard firstCard = state.getPath().peek();
-            int value = firstCard.getNumberOfGems();
+            int value = firstCard.getValue();
 
             if (firstCard.getCardType() == DiamantCard.DiamantCardType.Treasure) {
                 int expectedPerPlayer = value / 4;

--- a/src/test/java/games/diamant/DiamantExitTest.java
+++ b/src/test/java/games/diamant/DiamantExitTest.java
@@ -1,0 +1,141 @@
+package games.diamant;
+
+import core.Game;
+import core.actions.AbstractAction;
+import games.GameType;
+import games.diamant.actions.ContinueInCave;
+import games.diamant.actions.ExitFromCave;
+import games.diamant.cards.DiamantCard;
+import games.diamant.cards.DiamantCard.HazardType;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static games.diamant.cards.DiamantCard.DiamantCardType.Hazard;
+import static org.junit.Assert.assertEquals;
+
+public class DiamantExitTest {
+
+    DiamantForwardModel fm = new DiamantForwardModel();
+
+    @Test
+    public void testGemsOnNewCardDivided() {
+        // Setup game for 4 players
+        for (int seed = 0; seed < 20; seed++) {
+
+            DiamantParameters params = new DiamantParameters();
+            params.setRandomSeed(seed * 37);
+            Game game = new Game(GameType.Diamant, fm, new DiamantGameState(params, 4));
+
+            DiamantGameState state = (DiamantGameState) game.getGameState();
+            state.mainDeck.add(new DiamantCard(DiamantCard.DiamantCardType.Treasure, HazardType.None, 5));
+
+            // All players are in the cave at the start
+            assertEquals(4, state.getNPlayersInCave());
+
+            // with one cards added at the start of the game
+            assertEquals(1, state.gemsOnPath.size());
+            int firstCardResidue = state.gemsOnPath.get(0);
+            int firstCardCollected = state.hands.get(0).getValue();
+
+            // Prepare actions: players 0 and 1 exit, 2 and 3 continue
+            AbstractAction[] actions = new AbstractAction[4];
+            actions[0] = new ExitFromCave();
+            actions[1] = new ExitFromCave();
+            actions[2] = new ContinueInCave();
+            actions[3] = new ContinueInCave();
+
+            // Simulate all players submitting their actions
+            for (int i = 0; i < 4; i++) {
+                assertEquals(i, state.getCurrentPlayer());
+                fm.next(state, actions[i]);
+            }
+            assertEquals(0, state.getCurrentPlayer());
+            assertEquals(5, state.getPath().get(0).getNumberOfGems());
+
+            // After the move, 2 players should have left the cave, 2 remain
+            assertEquals(2, state.playerInCave.stream().filter(b -> b).count());
+
+            assertEquals(2, state.getNPlayersInCave());
+
+            assertEquals(2, state.gemsOnPath.size());
+            assertEquals(1, (int) state.gemsOnPath.get(1));
+            assertEquals(0, state.hands.get(0).getValue());
+            assertEquals(firstCardCollected + firstCardResidue / 2, state.treasureChests.get(0).getValue());
+            assertEquals(0, state.hands.get(1).getValue());
+            assertEquals(firstCardCollected + firstCardResidue / 2, state.treasureChests.get(1).getValue());
+            assertEquals(2 + firstCardCollected, state.hands.get(2).getValue());
+            assertEquals(2 + firstCardCollected, state.hands.get(3).getValue());
+        }
+    }
+
+    @Test
+    public void testTreasureDivisionOnFirstCardForMultipleSeeds() {
+        for (int seed = 0; seed < 20; seed++) {
+            DiamantParameters params = new DiamantParameters();
+            params.setRandomSeed(seed * 31);
+            Game game = new Game(GameType.Diamant, fm, new DiamantGameState(params, 4));
+
+            DiamantGameState state = (DiamantGameState) game.getGameState();
+
+            // There should be exactly one card in the path after setup
+            assertEquals(1, state.getPath().getSize());
+            System.out.println(state.getPath().get(0));
+
+            DiamantCard firstCard = state.getPath().peek();
+            int value = firstCard.getNumberOfGems();
+
+            if (firstCard.getCardType() == DiamantCard.DiamantCardType.Treasure) {
+                int expectedPerPlayer = value / 4;
+                int expectedRemainder = value % 4;
+                System.out.println(expectedPerPlayer + " " + expectedRemainder);
+
+                for (int p = 0; p < 4; p++) {
+                    assertEquals(expectedPerPlayer, state.getHands().get(p).getValue());
+                }
+                assertEquals(1, state.gemsOnPath.size());
+                assertEquals(expectedRemainder, (int) state.gemsOnPath.get(0));
+            }
+        }
+    }
+
+    @Test
+    public void testHazardCardRemovedEachRound() {
+        DiamantParameters params = new DiamantParameters();
+        params.setRandomSeed(12345);
+        Game game = new Game(GameType.Diamant, fm, new DiamantGameState(params, 4));
+        DiamantGameState state = (DiamantGameState) game.getGameState();
+
+        Map<HazardType, Long> initialHazardCounts = hazardCount(state);
+        int currentCave = state.nCave;
+
+        while (state.isNotTerminal()) {
+            // All players continue until the cave ends (by double hazard)
+            DiamantCard lastCard;
+            do {
+                lastCard = state.mainDeck.peek();
+                for (int i = 0; i < 4; i++) {
+                    if (state.playerInCave.get(i)) {
+                        fm.next(state, new ContinueInCave());
+                    }
+                }
+            } while (currentCave == state.nCave);
+            if (state.isNotTerminal()) {
+                System.out.println(currentCave + " : " + lastCard.getHazardType());
+                assertEquals(Hazard, lastCard.getCardType());
+                Map<HazardType, Long> hazardCounts = hazardCount(state);
+                assertEquals(1, initialHazardCounts.get(lastCard.getHazardType()) - hazardCounts.get(lastCard.getHazardType()));
+                currentCave++;
+                initialHazardCounts = hazardCounts;
+            }
+        }
+    }
+
+
+    private Map<HazardType, Long> hazardCount(DiamantGameState state) {
+        return state.mainDeck.stream().filter(c -> c.getCardType() == Hazard)
+                .collect(Collectors.groupingBy(DiamantCard::getHazardType, Collectors.counting()));
+    }
+}

--- a/src/test/java/games/diamant/DiamantRelicTest.java
+++ b/src/test/java/games/diamant/DiamantRelicTest.java
@@ -62,6 +62,11 @@ public class DiamantRelicTest {
         // After first move, 3 players have left, 1 remains
         assertEquals(1, state.getNPlayersInCave());
 
+        // check relic is in path
+        assertEquals(1, state.getPath().stream().
+                filter(c -> c.getCardType() == DiamantCardType.Relic)
+                .count());
+
         // Next move: last player exits
         int currentScore = state.hands.get(3).getValue(); // Player 3 is the last one in the cave
         int expectedScoreIncrease = 5 + state.gemsOnPath.stream().mapToInt(i -> i).sum(); // 5 from relic, plus gems on path
@@ -99,6 +104,11 @@ public class DiamantRelicTest {
         for (int i = 0; i < 4; i++) {
             currentScores[i] = state.hands.get(i).getValue();
         }
+
+        // check relic is still in path
+        assertEquals(1, state.getPath().stream().
+                filter(c -> c.getCardType() == DiamantCardType.Relic)
+                .count());
 
         // Next move: both remaining players exit
         executePlayerActions(game, state, new boolean[]{false, false, false, false});

--- a/src/test/java/games/diamant/DiamantRelicTest.java
+++ b/src/test/java/games/diamant/DiamantRelicTest.java
@@ -1,0 +1,38 @@
+package games.diamant;
+
+import core.Game;
+import games.GameType;
+import games.diamant.cards.DiamantCard;
+import games.diamant.cards.DiamantCard.DiamantCardType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DiamantRelicTest {
+
+    @Test
+    public void testRelicVariantSetup() {
+        // Set up the game with relicVariant enabled
+        DiamantParameters params = new DiamantParameters();
+        params.setParameterValue("relicVariant", true);
+        Game game = new Game(GameType.Diamant, new DiamantForwardModel(), new DiamantGameState(params, 4));
+
+        DiamantGameState state = (DiamantGameState) game.getGameState();
+
+        // Check that there is exactly one Relic card in the deck
+        long relicCountInDeck = state.getMainDeck().stream()
+                .filter(card -> card.getCardType() == DiamantCardType.Relic)
+                .count();
+        assertEquals(1, relicCountInDeck);
+
+        // Check that there are four relics in the relic pile
+        assertEquals(4, state.getRelicDeck().getSize());
+
+        // Check that the Relic card in the deck has a value of 5
+        DiamantCard relicCard = state.getMainDeck().stream()
+                .filter(card -> card.getCardType() == DiamantCardType.Relic)
+                .findFirst()
+                .orElse(null);
+        assertEquals(5, relicCard.getValue());
+    }
+}

--- a/src/test/java/games/diamant/DiamantRelicTest.java
+++ b/src/test/java/games/diamant/DiamantRelicTest.java
@@ -1,12 +1,19 @@
 package games.diamant;
 
 import core.Game;
+import core.actions.AbstractAction;
 import games.GameType;
+import games.diamant.actions.ContinueInCave;
+import games.diamant.actions.ExitFromCave;
+import games.diamant.actions.OutOfCave;
 import games.diamant.cards.DiamantCard;
 import games.diamant.cards.DiamantCard.DiamantCardType;
 import org.junit.Test;
 
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class DiamantRelicTest {
 
@@ -16,8 +23,9 @@ public class DiamantRelicTest {
         DiamantParameters params = new DiamantParameters();
         params.setParameterValue("relicVariant", true);
         Game game = new Game(GameType.Diamant, new DiamantForwardModel(), new DiamantGameState(params, 4));
-
         DiamantGameState state = (DiamantGameState) game.getGameState();
+
+        removeRelicsFromPath(state);
 
         // Check that there is exactly one Relic card in the deck
         long relicCountInDeck = state.getMainDeck().stream()
@@ -34,5 +42,146 @@ public class DiamantRelicTest {
                 .findFirst()
                 .orElse(null);
         assertEquals(5, relicCard.getValue());
+    }
+
+    @Test
+    public void testRelicPickupAndNextCave() {
+        // Set up the game with relicVariant enabled
+        DiamantParameters params = new DiamantParameters();
+        params.setParameterValue("relicVariant", true);
+        Game game = new Game(GameType.Diamant, new DiamantForwardModel(), new DiamantGameState(params, 4));
+        DiamantGameState state = (DiamantGameState) game.getGameState();
+        removeRelicsFromPath(state);
+
+        // Place a treasure as the first card, and a relic as the second card in the path
+        placeRelicAsSecondPathCard(state, 5);
+
+        // First move: 3 exit, 1 continues
+        executePlayerActions(game, state, new boolean[]{false, false, false, true});
+
+        // After first move, 3 players have left, 1 remains
+        assertEquals(1, state.getNPlayersInCave());
+
+        // Next move: last player exits
+        int currentScore = state.hands.get(3).getValue(); // Player 3 is the last one in the cave
+        int expectedScoreIncrease = 5 + state.gemsOnPath.stream().mapToInt(i -> i).sum(); // 5 from relic, plus gems on path
+        executePlayerActions(game, state, new boolean[]{false, false, false, false});
+
+        // After this, all players have left, cave ends, new cave is prepared
+        // Player 3 should have picked up the relic (value 5)
+        assertEquals(currentScore + expectedScoreIncrease, state.getTreasureChests().get(3).getValue());
+
+        removeRelicsFromPath(state);
+        // Prepare for the next cave: there should be a relic of value 7 in the main deck
+        assertRelicsInMainDeck(state, new int[]{7});
+    }
+
+    @Test
+    public void testRelicNotPickedUpWithTwoPlayers() {
+        // Set up the game with relicVariant enabled
+        DiamantParameters params = new DiamantParameters();
+        params.setParameterValue("relicVariant", true);
+        Game game = new Game(GameType.Diamant, new DiamantForwardModel(), new DiamantGameState(params, 4));
+        DiamantGameState state = (DiamantGameState) game.getGameState();
+        removeRelicsFromPath(state);
+
+        // Place relic as second card in path (reuse helper)
+        placeRelicAsSecondPathCard(state, 5);
+
+        // First move: 2 exit, 2 continue
+        executePlayerActions(game, state, new boolean[]{false, false, true, true});
+
+        // After first move, 2 players remain
+        assertEquals(2, state.getNPlayersInCave());
+
+        int[] currentScores = new int[4];
+        int expectedIncrease = state.gemsOnPath.stream().mapToInt(g -> g / 2).sum();
+        for (int i = 0; i < 4; i++) {
+            currentScores[i] = state.hands.get(i).getValue();
+        }
+
+        // Next move: both remaining players exit
+        executePlayerActions(game, state, new boolean[]{false, false, false, false});
+
+        // No player should have received the relic bonus
+        for (int i = 2; i < 4; i++) {
+            assertEquals(currentScores[i] + expectedIncrease, state.getTreasureChests().get(i).getValue());
+        }
+
+        // Prepare for the next cave: there should be a relic of value 7 in the main deck
+        assertRelicsInMainDeck(state, new int[]{7});
+    }
+
+    @Test
+    public void testNoRelicDrawnBothRelicsInNextCave() {
+        // Set up the game with relicVariant enabled
+        DiamantParameters params = new DiamantParameters();
+        params.setParameterValue("relicVariant", true);
+        Game game = new Game(GameType.Diamant, new DiamantForwardModel(), new DiamantGameState(params, 4));
+        DiamantGameState state = (DiamantGameState) game.getGameState();
+        removeRelicsFromPath(state);
+
+        // Do not place any relic in the path; just play a normal round
+        // First move: all players exit
+        executePlayerActions(game, state, new boolean[]{false, false, false, false});
+
+        // After this, all players have left, cave ends, new cave is prepared
+        // Both relics (5 and 7) should be present in the main deck for the new cave
+        removeRelicsFromPath(state);
+        assertRelicsInMainDeck(state, new int[]{5, 7});
+    }
+
+    // --- Helper for both tests ---
+    private void placeRelicAsSecondPathCard(DiamantGameState state, int relicValue) {
+        // Find the relic in the main deck, extract it, and put it at the front
+        DiamantCard relicCard = state.getMainDeck().stream()
+                .filter(card -> card.getCardType() == DiamantCardType.Relic && card.getValue() == relicValue)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Expected relic card not found in main deck"));
+        state.getMainDeck().remove(relicCard);
+        state.getPath().add(relicCard); // Add relic to the path
+    }
+    private void removeRelicsFromPath(DiamantGameState state) {
+        // if there are any relics or hazards on the path, remove them and replace with a zero gem card
+        for (int i = 0; i < state.getPath().getSize(); i++) {
+            DiamantCard card = state.getPath().get(i);
+            if (card.getCardType() == DiamantCardType.Relic || card.getCardType() == DiamantCardType.Hazard) {
+                state.getPath().remove(i);
+                state.getPath().add(new DiamantCard(DiamantCardType.Treasure, null, 0), i);
+                state.mainDeck.add(card);
+            }
+        }
+
+    }
+
+    // Helper: Check that the main deck contains exactly the relics with the given values
+    private void assertRelicsInMainDeck(DiamantGameState state, int[] expectedRelicValues) {
+        java.util.List<Integer> relicsInDeck = state.getMainDeck().stream()
+                .filter(card -> card.getCardType() == DiamantCardType.Relic)
+                .map(DiamantCard::getValue)
+                .sorted()
+                .toList();
+        int[] actual = relicsInDeck.stream().mapToInt(Integer::intValue).toArray();
+        int[] expected = expectedRelicValues.clone();
+        java.util.Arrays.sort(expected);
+        assertEquals(java.util.Arrays.toString(expected), java.util.Arrays.toString(actual));
+    }
+
+    // Helper: Execute player actions for a round.
+    // For each player, true = stay (ContinueInCave), false = leave (ExitFromCave), null = OutOfCave
+    private void executePlayerActions(Game game, DiamantGameState state, boolean[] stayOrLeave) {
+        AbstractAction[] actions = new AbstractAction[stayOrLeave.length];
+        for (int i = 0; i < stayOrLeave.length; i++) {
+            if (!state.playerInCave.get(i)) {
+                actions[i] = new OutOfCave();
+            } else if (stayOrLeave[i]) {
+                actions[i] = new ContinueInCave();
+            } else {
+                actions[i] = new ExitFromCave();
+            }
+        }
+        for (int i = 0; i < stayOrLeave.length; i++) {
+            game.getForwardModel().next(state, actions[i]);
+        }
     }
 }


### PR DESCRIPTION
This adds three things for Diamant:

1) Correctly implements the division of gems left on the path between players who leave. This is now down on a tile by tile basis, and not a single division of all gems.

2) Implements the relics variant, in which a relic is added to each of the 5 caves and provides additional bonus points if a single player leaves and can pick it up on the way out. This is on by default, but there is a boolean flag in DiamantParameters to turn it on/off.

3) A GUI has been added.