### PR TITLE
Sushi go fixes

### DIFF
--- a/src/main/java/games/sushigo/SGParameters.java
+++ b/src/main/java/games/sushigo/SGParameters.java
@@ -14,8 +14,8 @@ public class SGParameters extends AbstractParameters {
     public int nRounds = 3;
 
     public HashMap<Pair<SGCard.SGCardType, Integer>, Integer> nCardsPerType = new HashMap<Pair<SGCard.SGCardType, Integer>, Integer>() {{
-        put(new Pair<>(SGCard.SGCardType.Maki, 3), 12);
-        put(new Pair<>(SGCard.SGCardType.Maki, 2), 8);
+        put(new Pair<>(SGCard.SGCardType.Maki, 3), 8);
+        put(new Pair<>(SGCard.SGCardType.Maki, 2), 12);
         put(new Pair<>(SGCard.SGCardType.Maki, 1), 6);
         put(new Pair<>(SGCard.SGCardType.Chopsticks, 1), 4);
         put(new Pair<>(SGCard.SGCardType.Tempura, 1), 14);

--- a/src/main/java/games/sushigo/SGParameters.java
+++ b/src/main/java/games/sushigo/SGParameters.java
@@ -32,7 +32,8 @@ public class SGParameters extends AbstractParameters {
     public int valueMakiSecond = 3;
     public int valueTempuraPair = 5;
     public int valueSashimiTriple = 10;
-    public int[] valueDumpling = new int[] {1, 3, 6, 10, 15};
+    // dumpling values are incremental, e.g. 1 dumpling = 1 point, 2 = 3 points, 3 = 6 points, etc.
+    public int[] valueDumpling = new int[] {1, 2, 3, 4, 5};
     public int valueSquidNigiri = 3;
     public int valueSalmonNigiri = 2;
     public int valueEggNigiri = 1;

--- a/src/test/java/games/sushigo/testCardReveals.java
+++ b/src/test/java/games/sushigo/testCardReveals.java
@@ -1,0 +1,46 @@
+package games.sushigo;
+
+import core.actions.AbstractAction;
+import games.sushigo.actions.ChooseCard;
+import games.sushigo.cards.SGCard;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class testCardReveals {
+
+    SGGameState state;
+    SGParameters params;
+    SGForwardModel fm = new SGForwardModel();
+
+    @Before
+    public void setup() {
+        params = new SGParameters();
+        params.setRandomSeed(1234);
+        state = new SGGameState(params, 4);
+        fm.setup(state);
+    }
+
+    @Test
+    public void testTwoDumplings() {
+        // first we add two dumplings to player 0's hand
+        state.getPlayerHands().get(0).draw();
+        state.getPlayerHands().get(0).draw();
+        state.getPlayerHands().get(0).add(new SGCard(SGCard.SGCardType.Dumpling));
+        state.getPlayerHands().get(0).add(new SGCard(SGCard.SGCardType.Dumpling));
+        for (int i = 0; i < 8; i++) {
+            List<AbstractAction> actions = fm.computeAvailableActions(state);
+            AbstractAction action = (i % 4 != 0) ?
+                    actions.stream().map(a -> (ChooseCard) a)
+                            .filter(a -> state.getPlayerHands().get(0).get(a.cardIdx).type == SGCard.SGCardType.Dumpling)
+                            .findFirst().orElseThrow(() -> new RuntimeException("No dumpling found")) :
+                    actions.get(0);
+            fm.next(state, action);
+        }
+        assertEquals(2, state.getPlayedCards().get(0).stream().filter(c -> c.type == SGCard.SGCardType.Dumpling).count());
+        assertEquals(3, state.getGameScore(0), 0.001); // 2 dumplings = 3 points
+    }
+}


### PR DESCRIPTION
Two fixes for Sushi Go:
1) Correct number of Maki 2 and Maki 3 cards (the counts were flipped in game parameters)
2) Fix for Dumpling scoring